### PR TITLE
Assign agent for signaling assessment

### DIFF
--- a/may29_xjp/src/may20_xjp_2/config/tasks.yaml
+++ b/may29_xjp/src/may20_xjp_2/config/tasks.yaml
@@ -124,6 +124,7 @@ assess_signaling_and_recommend_strategic_path_task:
   context:
     - analyze_event_task
     - develop_active_strategic_postures_task
+  agent: StrategicSignalingAssessmentAgent
 
 generate_active_pla_options_task:
   description: >


### PR DESCRIPTION
## Summary
- assign `StrategicSignalingAssessmentAgent` to the `assess_signaling_and_recommend_strategic_path_task`

## Testing
- `pre-commit run --files may29_xjp/src/may20_xjp_2/config/tasks.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68425fe6007c832dae0f2053e2563b7d