### PR TITLE
Fix digest dependencies

### DIFF
--- a/may29_xjp/src/may20_xjp_2/config/tasks.yaml
+++ b/may29_xjp/src/may20_xjp_2/config/tasks.yaml
@@ -68,7 +68,9 @@ internal_impact_narrative_task:
     and recommended internal narrative management strategies.
   agent: DomesticSentimentStabilityAnalyst
   context:
-    - curate_context_digest_task.digest
+    - analyze_event_task
+    - assess_economic_tech_impact_task
+    - historical_context_task
 
 develop_active_strategic_postures_task:
   description: >
@@ -188,7 +190,11 @@ develop_strategic_communication_plan_task:
     A concise Strategic Communication Plan document.
   agent: StrategicNarrativeAndInfluenceAgent
   context:
-    - curate_context_digest_task.digest
+    - analyze_event_task
+    - assess_signaling_and_recommend_strategic_path_task
+    - generate_active_pla_options_task
+    - develop_active_diplomatic_strategy_task
+    - ideological_perception_task
 # instead of pulling seven separate blobs.
 
 curate_context_digest_task:


### PR DESCRIPTION
## Summary
- update `internal_impact_narrative_task` to reference upstream analysis tasks
- update `develop_strategic_communication_plan_task` with direct task contexts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684260b16470832d9b68c2b77e1b7426