### PR TITLE
Update context digest with domestic and historical insights

### DIFF
--- a/may29_xjp/src/may20_xjp_2/config/tasks.yaml
+++ b/may29_xjp/src/may20_xjp_2/config/tasks.yaml
@@ -192,23 +192,27 @@ develop_strategic_communication_plan_task:
 # instead of pulling seven separate blobs.
 
 curate_context_digest_task:
-  description: >
-    Collate the following into a single digest ≤600 tokens:
-      – {context.analyze_event_task.core_event_details}
-      – {context.assess_signaling_and_recommend_strategic_path_task.output}
-      – {context.generate_active_pla_options_task.military_options}
-      – {context.develop_active_diplomatic_strategy_task.keystone_statement}
-      – {context.ideological_perception_task.key_frames}
+    description: >
+      Collate the following into a single digest ≤600 tokens:
+        – {context.analyze_event_task.core_event_details}
+        – {context.assess_signaling_and_recommend_strategic_path_task.output}
+        – {context.generate_active_pla_options_task.military_options}
+        – {context.develop_active_diplomatic_strategy_task.keystone_statement}
+        – {context.ideological_perception_task.key_frames}
+        – {context.historical_context_task.output}
+        – {context.internal_impact_narrative_task.output}
   expected_output: |
     digest: |
       "… consolidated bullet list …"
-  context:
-    - analyze_event_task
-    - assess_signaling_and_recommend_strategic_path_task
-    - generate_active_pla_options_task
-    - develop_active_diplomatic_strategy_task
-    - ideological_perception_task
-  agent: ContextCuratorAgent
+    context:
+      - analyze_event_task
+      - assess_signaling_and_recommend_strategic_path_task
+      - generate_active_pla_options_task
+      - develop_active_diplomatic_strategy_task
+      - ideological_perception_task
+      - historical_context_task
+      - internal_impact_narrative_task
+    agent: ContextCuratorAgent
 
 
 format_final_response_task:


### PR DESCRIPTION
## Summary
- enrich `curate_context_digest_task` to include historical and domestic-sentiment outputs
- update context list so digest compiles results from all analysts

## Testing
- `uv run pytest -q` *(fails: external_memory_test, user_memory_test, test_mem0_storage)*

------
https://chatgpt.com/codex/tasks/task_e_684262f92398832d801a4ea550a1171c