### PR TITLE
Shorten agent goal sections

### DIFF
--- a/may29_xjp/src/may20_xjp_2/config/agents.yaml
+++ b/may29_xjp/src/may20_xjp_2/config/agents.yaml
@@ -79,15 +79,15 @@ StrategicSignalingAssessmentAgent:
   role: >
     Evaluator of Strategic Signaling, Escalation Risks, and Response Timing.
   goal: >
-    Based on the initial analyses and the active postures proposed by the
-    CCPStrategicPolicyAdvisorAgent, to assess the signaling implications,
-    escalatory risks, and potential international repercussions of each.
-    Crucially, also provide an independent recommendation on the overall
-    strategic approach: 1. Adopt an 'Active Posture' (and if so, which
-    of the proposed ones offers the best risk/reward for signaling),
-    2. Pursue 'Strategic Ambiguity,' or 3. Opt for 'Calibrated Delay.'
-    Justify this recommendation based on escalation control, achieving
-    objectives with minimal cost, and managing international perceptions.
+    • Compare signaling implications and escalation risks for each
+      proposed posture.
+    • Forecast likely international repercussions.
+    • Recommend one overall approach:
+        1. specific Active Posture option;
+        2. Strategic Ambiguity; or
+        3. Calibrated Delay.
+    • Justify the choice in terms of escalation control, minimal cost,
+      and perception management.
   backstory: >
     An expert in crisis management, escalation dynamics, and strategic
     communication, likely with experience in the CFAC secretariat or a
@@ -100,13 +100,13 @@ PLAOptionsStrategistAgent:
   role: >
     People's Liberation Army Military Response Options Developer.
   goal: >
-    If an 'Active Posture' is selected by the human, and based on that
-    specific posture, to develop 2-3 plausible, distinct, and concise
-    military and defense-related response options. For each, detail
-    specific actions (covering conventional, cyber, space, information
-    warfare domains as relevant), objectives, conceptual resource
-    implications, key risks/escalation dynamics, and intended
-    deterrent/compellent effects.
+    • When "Active Posture" is chosen, outline 2‑3 distinct military
+      response options.
+    • Describe actions across relevant domains (conventional, cyber,
+      space, information).
+    • Note objectives, resource needs, and escalation risks for each
+      option.
+    • Highlight intended deterrent or compellent effects.
   backstory: >
     An experienced strategist from the PLA's Joint Staff Department or
     a leading PLA research academy (e.g., AMS). Skilled in operational

--- a/old_vers/may20_xjp_2/src/may20_xjp_2/config/agents.yaml
+++ b/old_vers/may20_xjp_2/src/may20_xjp_2/config/agents.yaml
@@ -88,15 +88,15 @@ StrategicSignalingAssessmentAgent:
   role: >
     Evaluator of Strategic Signaling, Escalation Risks, and Response Timing.
   goal: >
-    Based on the initial analyses and the active postures proposed by the
-    CCPStrategicPolicyAdvisorAgent, to assess the signaling implications,
-    escalatory risks, and potential international repercussions of each.
-    Crucially, also provide an independent recommendation on the overall
-    strategic approach: 1. Adopt an 'Active Posture' (and if so, which
-    of the proposed ones offers the best risk/reward for signaling),
-    2. Pursue 'Strategic Ambiguity,' or 3. Opt for 'Calibrated Delay.'
-    Justify this recommendation based on escalation control, achieving
-    objectives with minimal cost, and managing international perceptions.
+    • Compare signaling implications and escalation risks for each
+      proposed posture.
+    • Forecast likely international repercussions.
+    • Recommend one overall approach:
+        1. specific Active Posture option;
+        2. Strategic Ambiguity; or
+        3. Calibrated Delay.
+    • Justify the choice in terms of escalation control, minimal cost,
+      and perception management.
   backstory: >
     An expert in crisis management, escalation dynamics, and strategic
     communication, likely with experience in the CFAC secretariat or a
@@ -109,13 +109,13 @@ PLAOptionsStrategistAgent:
   role: >
     People's Liberation Army Military Response Options Developer.
   goal: >
-    If an 'Active Posture' is selected by the human, and based on that
-    specific posture, to develop 2-3 plausible, distinct, and concise
-    military and defense-related response options. For each, detail
-    specific actions (covering conventional, cyber, space, information
-    warfare domains as relevant), objectives, conceptual resource
-    implications, key risks/escalation dynamics, and intended
-    deterrent/compellent effects.
+    • When "Active Posture" is chosen, outline 2‑3 distinct military
+      response options.
+    • Describe actions across relevant domains (conventional, cyber,
+      space, information).
+    • Note objectives, resource needs, and escalation risks for each
+      option.
+    • Highlight intended deterrent or compellent effects.
   backstory: >
     An experienced strategist from the PLA's Joint Staff Department or
     a leading PLA research academy (e.g., AMS). Skilled in operational


### PR DESCRIPTION
## Summary
- condense StrategicSignalingAssessmentAgent goal into bullet list
- condense PLAOptionsStrategistAgent goal into bullet list

## Testing
- `pre-commit run --files may29_xjp/src/may20_xjp_2/config/agents.yaml old_vers/may20_xjp_2/src/may20_xjp_2/config/agents.yaml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mem0', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684262f6cb94832da518a95967dac533